### PR TITLE
Prefer getOfflinePlayerIfCached over iteration

### DIFF
--- a/src/main/java/simplexity/simplenicks/commands/arguments/OfflinePlayerArgument.java
+++ b/src/main/java/simplexity/simplenicks/commands/arguments/OfflinePlayerArgument.java
@@ -41,13 +41,8 @@ public class OfflinePlayerArgument implements CustomArgumentType<OfflinePlayer, 
     @Override
     public @NotNull OfflinePlayer parse(@NotNull StringReader reader) throws CommandSyntaxException {
         String playerName = reader.readString();
-        for (Player player : Bukkit.getOnlinePlayers()) {
-            if (player.getName().equalsIgnoreCase(playerName)) return player;
-        }
-        for (OfflinePlayer player : Bukkit.getOfflinePlayers()) {
-            if (player.getName() == null || player.getName().isEmpty()) continue;
-            if (player.getName().equalsIgnoreCase(playerName)) return player;
-        }
+        OfflinePlayer player = Bukkit.getOfflinePlayerIfCached(playerName);
+        if (player != null) return player;
         throw Exceptions.INVALID_PLAYER_SPECIFIED.create(playerName);
     }
 

--- a/src/main/java/simplexity/simplenicks/config/LocaleMessage.java
+++ b/src/main/java/simplexity/simplenicks/config/LocaleMessage.java
@@ -20,7 +20,7 @@ public enum LocaleMessage {
     SERVER_DISPLAY_NAME("plugin.server-display-name", "<gray>[Server]</gray>"),
 
     // Basic Functionality
-    SET_SELF("nick.set.self", "<green>Changed your nickname to <value><green>!"),
+    SET_SELF("nick.set.self", "<green>Changed your nickname to <reset><value><green>!"),
     SET_TARGET("nick.set.target", "<green>Changed <target>'s nickname to <value>"),
     SET_BY_INITIATOR("nick.set.by-initiator", "<green><initiator> changed your nickname to <reset><value><green>!"),
     RESET_SELF("nick.reset.self", "<green>Reset your nickname!"),


### PR DESCRIPTION
This PR is intended to fix a performance concern with our implementation of finding a player regardless of if they are online or offline.

In spite of the small change that may as well go to straight to master, I think that given I already made the mistake of publishing v3.2.2, we may as well just take a moment to add any additional patch-level (or minor if appropriate) changes needed. Also, I feel my mistake on v3.2.2 may have been caught in PQA if it was done.

Also, before merging, ensure:
- [ ] Bump Version